### PR TITLE
readme fix and video_main support for custom output name

### DIFF
--- a/Deteccção de discurso de ódio/Classificação.ipynb
+++ b/Deteccção de discurso de ódio/Classificação.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b97837bf",
    "metadata": {},
    "outputs": [
@@ -20,6 +20,7 @@
    ],
    "source": [
     "import pandas as pd\n",
+    "!pip install detoxify\n",
     "from detoxify import Detoxify\n",
     "from tqdm.auto import tqdm\n",
     "from IPython.display import clear_output\n",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# YTLiveComments
+# StreamVis 2.0
 
 ## ⚙️ Installation
 ##### Clone the repository
 ```bash
-git clone https://github.com/StefanoDPCarraro/YTLiveComments.git
-cd YTLiveComments
+git clone https://github.com/DAVINTLAB/StreamVis-2.git
+cd StreamVis-2
 ```
 
 ##### Setup venv (recommended):
@@ -26,13 +26,27 @@ source ambiente_youtube/bin/activate
 pip install -r requirements.txt
 ```
 
-##### Open the main.py file and insert your API key and Video ID
+##### Create a .env file and insert your GOOGLE API key and Youtube Video ID
 ```bash
-7 - API_KEY = ''
+7 - GOOGLE_API_KEY = ''
 8 - VIDEO_ID = ''
+```
+
+## 🔎 Gathering Data
+Before running StreamVis, you will need a file with YouTube comments data.
+
+To collect YouTube comments from a video, run the script video_main.py
+```bash
+python3 video_main.py
+```
+The output file will be saved as `youtube_comments.json`.
+
+You can also define a different name for the output file using the parameter -o when running the script:
+```bash
+python3 video_main.py -o custom_output_name.json
 ```
 
 ## 🚀Run
 ```bash
-python3 main.py
+streamlit run app.py
 ```

--- a/app_pages/analyzed_comments/analyzed_upload.py
+++ b/app_pages/analyzed_comments/analyzed_upload.py
@@ -40,11 +40,11 @@ def analyzed_upload():
     
     #List and handle changes for uploaded archieves
     if st.session_state.analyzed_csv_files:
-        file_name = st.selectbox('Uploaded archieves', st.session_state.analyzed_csv_files.keys())
+        file_name = st.selectbox('Uploaded archives', st.session_state.analyzed_csv_files.keys())
         st.dataframe(st.session_state.analyzed_csv_files[file_name])
 
         if(st.button('Remove file')):
             del st.session_state.analyzed_csv_files[file_name]
     
     else:
-        st.info('No csv archieve')
+        st.info('No csv archive')

--- a/app_pages/analyzed_comments/wordcloud.py
+++ b/app_pages/analyzed_comments/wordcloud.py
@@ -8,7 +8,7 @@ def wordcloud_page():
         st.warning('No data uploaded, please upload some data before checking this page')
         return
     
-    file_name = st.selectbox('Uploaded archieves', st.session_state.analyzed_csv_files.keys())
+    file_name = st.selectbox('Uploaded archives', st.session_state.analyzed_csv_files.keys())
 
     classification_col = ['Desempate']
 

--- a/video_main.py
+++ b/video_main.py
@@ -1,6 +1,7 @@
 import json
 import os
 import requests
+import argparse
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -15,7 +16,7 @@ params = {
     "maxResults": 100  # Pega até 100 comentários por página
 }
 
-def get_video_comments():
+def get_video_comments(output_file):
     comments = []
     next_page_token = None
 
@@ -27,7 +28,7 @@ def get_video_comments():
         data = response.json()
 
         if "items" not in data:
-            print("Nenhum comentário encontrado")
+            print("No comment found")
             break
         
         for item in data["items"]:
@@ -42,13 +43,20 @@ def get_video_comments():
         if not next_page_token:
             break
     
-    output_file = "youtube_comments.json"
     with open(output_file, "w", encoding="utf-8") as file:
         json.dump(comments, file, ensure_ascii=False, indent=4)
 
-    print(f"Total de comentários coletados: {len(comments)}")
-    print(f"Comentários salvos em: {output_file}")
+    print(f"Ammount of comments collected: {len(comments)}")
+    print(f"Comments saved in: {output_file}")
 
 
 if __name__ == "__main__":
-    get_video_comments()
+    parser = argparse.ArgumentParser(description="Collects comments in a YouTube video.")
+    parser.add_argument(
+        "-o", "--output",
+        type=str,
+        default="youtube_comments.json",
+        help="Output file name (default: youtube_comments.json)"
+    )
+    args = parser.parse_args()
+    get_video_comments(output_file=args.output)


### PR DESCRIPTION
Atualização do README e alterações no script video_main.py para que ele aceite o nome do arquivo de output como parâmetro. O notebook de classificação de discurso de ódio também foi modificado para arrumar o import do detoxify que falhava ao ser executado no google colab ou qualquer outro ambiente que não possuia o modelo instalado.